### PR TITLE
Fix bug in settings modal

### DIFF
--- a/src/math-games/connect-four/ConnectFourController.js
+++ b/src/math-games/connect-four/ConnectFourController.js
@@ -133,6 +133,7 @@ export default function ConnectFourController(props) {
     // console.log(`STARTING NEW GAME with SETTINGS: ${JSON.stringify(settings, null, 4)}`);
     setSettings(settings)
     setMoveList([])
+    setOpenModal("none")
   }
 
   function cancelNewGame() {

--- a/src/math-games/connect-four/modals/SettingsModal.js
+++ b/src/math-games/connect-four/modals/SettingsModal.js
@@ -229,7 +229,8 @@ export function SettingsModal(props) {
       />
     )
   }
-  function StartGameButton() {
+  function StartGameButton(props) {
+    const { startNewGame } = props
     return (
       <Button
         onClick={() => startNewGame(settings)}


### PR DESCRIPTION
The modal was not receiving props so it was trying to call the startNewGame function even though this was never passed in.