### PR TITLE
Remove openModal setter from derived state useEffect

### DIFF
--- a/src/math-games/connect-four/ConnectFourContext.js
+++ b/src/math-games/connect-four/ConnectFourContext.js
@@ -70,7 +70,6 @@ export const ConnectFourContextProvider = props => {
     setLowestUnclaimedCells(getLowestUnclaimedCells(moveList))
 
     setActiveCell(null) 
-    setOpenModal("none")
     setHeaderText("")
 
   },[moveList])

--- a/src/math-games/connect-four/ConnectFourController.js
+++ b/src/math-games/connect-four/ConnectFourController.js
@@ -133,6 +133,7 @@ export default function ConnectFourController(props) {
     // console.log(`STARTING NEW GAME with SETTINGS: ${JSON.stringify(settings, null, 4)}`);
     setSettings(settings)
     setMoveList([])
+    setOpenModal("none")
   }
 
   function cancelNewGame() {


### PR DESCRIPTION
The useEffect that fires when the movelist updates was causing openModal to get set to 'none' when the moveList was set to newGame state before the Welcome modal had a chance to render.